### PR TITLE
Makefile reana command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PH_REPOSITORY="madminer-workflow-ph"
 ML_REPOSITORY="madminer-workflow-ml"
 
 
-all: copy reana-deploy yadage-clean yadage-run
+all: copy reana-run yadage-clean yadage-run
 
 
 .PHONY: copy
@@ -20,8 +20,8 @@ copy:
 	@cp -r "modules/$(ML_REPOSITORY)/workflow/." "$(WORKFLOW_FOLDER)/ml"
 
 
-.PHONY: reana-deploy
-reana-deploy: copy
+.PHONY: reana-run
+reana-run: copy
 	@echo "Deploying on REANA..."
 	@cd $(WORKFLOW_FOLDER) && \
 		reana-client create -n $(WORKFLOW_NAME) && \

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ $ source ~/.virtualenvs/reana/bin/activate
 (reana) $ eval $(reana-dev client-setup-environment)
 (reana) $ export REANA_WORKON=madminer-workflow
 (reana) $ export MLFLOW_TRACKING_URI=http://host.docker.internal:5000
-(reana) $ make reana-deploy
+(reana) $ make reana-run
 ```
 
 ### Remote deployment
@@ -113,7 +113,7 @@ $ source ~/.virtualenvs/reana/bin/activate
 (reana) $ export REANA_SERVER_URL=[..]
 (reana) $ export REANA_WORKON=madminer-workflow
 (reana) $ export MLFLOW_TRACKING_URI=<tracking_server_url>
-(reana) $ make reana-deploy
+(reana) $ make reana-run
 ```
 
 It might take some time to finish depending on the job and the cluster.


### PR DESCRIPTION
This PR renames the `reana-deploy` Makefile rule to `reana-run`.

This change makes it consistent with the existing `yadage-run` command.

cc @irinaespejo 