### PR TITLE
MLFlow local metrics storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 YADAGE_WORKDIR="$(PWD)/.yadage"
 
 MLFLOW_USERNAME ?= $(shell whoami)
-MLFLOW_TRACKING_URI ?= "/tmp/mlflow"
+MLFLOW_TRACKING_URI ?= "file:///_mlflow"
 
 WORKFLOW_FOLDER="$(PWD)/reana"
 WORKFLOW_NAME="madminer-workflow"

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ git submodule update --remote
 The [MLFlow][mlflow-website] framework has been integrated with some steps of the workflow
 in order to keep track of runs initial set of parameters, set of results, and generated artifacts.
 
-**Disclaimer: The existence of an up-and-running MLFlow tracking server is mandatory.**
-
 In order to locally deploy your own:
 ```shell script
 # Deploy local tracking server


### PR DESCRIPTION
This PR addresses issue https://github.com/scailfin/madminer-workflow/issues/40, by updating the reference to the [madminer-workflow-ml](https://github.com/scailfin/madminer-workflow-ml) latest version.

Upon this merge, Madminer-workflow **no longer needs** an _up-an-running_ MLFlow Tracking server to work on REANA.

---

For more information about how the local storage of MLFlow metrics was solved, check [this PR](https://github.com/scailfin/madminer-workflow-ml/pull/10).

