### PR TITLE
Define custom dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+
+  - package-ecosystem: gitsubmodule
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    ignore:
+      # Ignore auto-updates on SemVer major and minor releases
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    allow:
+      - dependency-type: development
+      - dependency-type: production


### PR DESCRIPTION
This PR activates 🤖  GitHub dependabot automatic updates on both GIT submodules and Python dependencies. The updates are triggered **weekly on Mondays** (default day).

### 📋 Considerations
- [SemVer](https://semver.org/) `minor` and `major` version updates are ignored for now, as a security measure.

### 📚  References
- [GitHub dependabot documentation](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates).